### PR TITLE
Make layout spacing more compact

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -54,19 +54,19 @@ h2,
 h3,
 h4 {
     font-weight: 700;
-    margin: 0 0 0.75em;
+    margin: 0 0 0.6em;
     line-height: 1.2;
 }
 
 p {
-    margin: 0 0 1.2em;
+    margin: 0 0 1em;
 }
 
 .btn {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    padding: 0.85em 1.8em;
+    padding: 0.75em 1.6em;
     border-radius: 999px;
     font-weight: 600;
     font-size: 0.95rem;
@@ -112,7 +112,7 @@ p {
 .nav {
     max-width: var(--max-width);
     margin: 0 auto;
-    padding: 28px 24px;
+    padding: 22px 20px;
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -133,7 +133,7 @@ p {
 
 .nav__links {
     display: flex;
-    gap: 22px;
+    gap: 18px;
     list-style: none;
     margin: 0;
     padding: 0;
@@ -183,7 +183,7 @@ p {
 }
 
 .hero {
-    padding-bottom: 96px;
+    padding-bottom: 72px;
     background: linear-gradient(160deg, rgba(31, 111, 235, 0.32) 0%, rgba(11, 13, 23, 0.6) 40%, rgba(11, 13, 23, 0.95) 100%);
 }
 
@@ -193,24 +193,24 @@ p {
     padding: 0 24px;
     display: grid;
     grid-template-columns: minmax(0, 1.15fr) minmax(0, 0.85fr);
-    gap: 40px;
+    gap: 28px;
     align-items: center;
 }
 
 .hero__tag {
     display: inline-block;
     background: rgba(255, 255, 255, 0.08);
-    padding: 8px 16px;
+    padding: 6px 14px;
     border-radius: 999px;
-    font-size: 0.85rem;
+    font-size: 0.82rem;
     letter-spacing: 0.1em;
     text-transform: uppercase;
-    margin-bottom: 24px;
+    margin-bottom: 16px;
 }
 
 .hero h1 {
-    font-size: clamp(2.5rem, 4vw + 1rem, 3.8rem);
-    margin-bottom: 20px;
+    font-size: clamp(2.3rem, 3.6vw + 1rem, 3.4rem);
+    margin-bottom: 16px;
 }
 
 .hero__description {
@@ -220,23 +220,23 @@ p {
 }
 
 .hero__note {
-    font-size: 1rem;
+    font-size: 0.98rem;
     color: rgba(247, 247, 251, 0.78);
-    margin: 0 0 20px;
+    margin: 0 0 16px;
     max-width: 620px;
 }
 
 .hero__list {
     list-style: none;
-    margin: 0 0 28px;
+    margin: 0 0 20px;
     padding: 0;
     display: grid;
-    gap: 14px;
+    gap: 12px;
 }
 
 .hero__list li {
     position: relative;
-    padding: 14px 18px 14px 48px;
+    padding: 12px 16px 12px 44px;
     border-radius: var(--radius-sm);
     background: rgba(255, 255, 255, 0.03);
     border: 1px solid rgba(255, 255, 255, 0.08);
@@ -248,7 +248,7 @@ p {
     content: '';
     position: absolute;
     left: 20px;
-    top: 20px;
+    top: 18px;
     width: 10px;
     height: 10px;
     border-radius: 50%;
@@ -263,36 +263,36 @@ p {
 .hero__cta {
     display: flex;
     flex-wrap: wrap;
-    gap: 16px;
-    margin-bottom: 26px;
+    gap: 12px;
+    margin-bottom: 20px;
 }
 
 .hero__stats {
     display: grid;
     grid-template-columns: repeat(3, minmax(0, 1fr));
-    gap: 20px;
-    margin: 32px 0 0;
+    gap: 16px;
+    margin: 24px 0 0;
 }
 
 .hero__stats dt {
-    font-size: 2.2rem;
+    font-size: 2rem;
     font-weight: 700;
     color: var(--accent);
 }
 
 .hero__stats dd {
-    margin: 6px 0 0;
+    margin: 4px 0 0;
     color: var(--muted);
-    font-size: 0.95rem;
+    font-size: 0.9rem;
 }
 
 .hero__signature {
-    margin-top: 32px;
-    padding-top: 24px;
+    margin-top: 24px;
+    padding-top: 20px;
     border-top: 1px solid rgba(255, 255, 255, 0.12);
     display: flex;
     flex-direction: column;
-    gap: 6px;
+    gap: 4px;
     max-width: 420px;
 }
 
@@ -308,7 +308,7 @@ p {
 
 .hero__aside {
     display: grid;
-    gap: 24px;
+    gap: 20px;
     align-content: start;
 }
 
@@ -332,11 +332,11 @@ p {
     left: 0;
     right: 0;
     bottom: 0;
-    padding: 22px 24px;
+    padding: 18px 20px;
     background: linear-gradient(0deg, rgba(11, 13, 23, 0.92), rgba(11, 13, 23, 0));
     display: flex;
     flex-direction: column;
-    gap: 6px;
+    gap: 4px;
 }
 
 .hero__portrait strong {
@@ -351,7 +351,7 @@ p {
 .hero__card {
     background: linear-gradient(135deg, rgba(16, 20, 37, 0.9), rgba(16, 20, 37, 0.6));
     border-radius: var(--radius-lg);
-    padding: 36px;
+    padding: 30px;
     box-shadow: var(--shadow);
     border: 1px solid rgba(255, 255, 255, 0.08);
     backdrop-filter: blur(18px);
@@ -363,7 +363,7 @@ p {
 
 .hero__card p {
     color: var(--muted);
-    margin-bottom: 24px;
+    margin-bottom: 20px;
 }
 
 .hero__form label {
@@ -372,7 +372,7 @@ p {
     text-transform: uppercase;
     letter-spacing: 0.08em;
     color: rgba(255, 255, 255, 0.72);
-    margin-bottom: 16px;
+    margin-bottom: 12px;
 }
 
 .hero__form input,
@@ -407,12 +407,12 @@ p {
 }
 
 .section {
-    padding: 100px 24px;
+    padding: 72px 24px;
 }
 
 .section__header {
     max-width: 720px;
-    margin: 0 auto 48px;
+    margin: 0 auto 36px;
     text-align: center;
 }
 
@@ -421,7 +421,7 @@ p {
     letter-spacing: 0.18em;
     text-transform: uppercase;
     color: var(--accent);
-    margin-bottom: 18px;
+    margin-bottom: 14px;
 }
 
 .section--about {
@@ -433,24 +433,24 @@ p {
     margin: 0 auto;
     display: grid;
     grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.9fr);
-    gap: 48px;
+    gap: 32px;
     align-items: start;
 }
 
 .about__intro {
     display: grid;
-    gap: 36px;
+    gap: 24px;
 }
 
 .about__profile {
     display: grid;
-    gap: 32px;
+    gap: 28px;
     align-items: start;
 }
 
 .about__content {
     display: grid;
-    gap: 18px;
+    gap: 16px;
 }
 
 .about__portrait {
@@ -504,7 +504,7 @@ p {
 @media (min-width: 1024px) {
     .about__profile {
         grid-template-columns: minmax(0, 1fr) minmax(280px, 0.85fr);
-        gap: 40px;
+        gap: 30px;
     }
 }
 
@@ -518,17 +518,17 @@ p {
 
 .about__highlights {
     list-style: none;
-    margin: 28px 0 0;
+    margin: 20px 0 0;
     padding: 0;
     display: grid;
-    gap: 18px;
+    gap: 14px;
 }
 
 .about__highlights li {
     background: rgba(255, 255, 255, 0.04);
     border: 1px solid rgba(255, 255, 255, 0.08);
     border-radius: var(--radius-md);
-    padding: 18px 22px;
+    padding: 16px 20px;
     display: grid;
     gap: 6px;
 }
@@ -543,17 +543,17 @@ p {
 .about__details {
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 24px;
+    gap: 20px;
 }
 
 .about-card {
     background: rgba(16, 20, 37, 0.78);
     border-radius: var(--radius-md);
-    padding: 28px;
+    padding: 24px;
     border: 1px solid rgba(255, 255, 255, 0.09);
     box-shadow: 0 22px 38px rgba(10, 12, 20, 0.48);
     display: grid;
-    gap: 18px;
+    gap: 14px;
 }
 
 .about-card h3 {
@@ -565,7 +565,7 @@ p {
     padding: 0;
     list-style: none;
     display: grid;
-    gap: 12px;
+    gap: 10px;
     color: rgba(255, 255, 255, 0.74);
 }
 
@@ -588,7 +588,7 @@ p {
 .about-card__stats {
     margin: 0;
     display: grid;
-    gap: 18px;
+    gap: 14px;
 }
 
 .about-card__stats div {
@@ -597,7 +597,7 @@ p {
 }
 
 .about-card__stats dt {
-    font-size: 1.7rem;
+    font-size: 1.6rem;
     font-weight: 700;
     color: var(--accent);
 }
@@ -625,7 +625,7 @@ p {
 .about-card__list--inline {
     display: flex;
     flex-wrap: wrap;
-    gap: 12px 20px;
+    gap: 10px 16px;
     color: rgba(255, 255, 255, 0.75);
 }
 
@@ -646,13 +646,13 @@ p {
     margin: 0 auto;
     display: grid;
     grid-template-columns: repeat(4, minmax(0, 1fr));
-    gap: 24px;
+    gap: 20px;
 }
 
 .service-card {
     background: var(--bg-alt);
     border-radius: var(--radius-md);
-    padding: 28px;
+    padding: 24px;
     border: 1px solid var(--border);
     box-shadow: 0 16px 30px rgba(10, 12, 20, 0.45);
     transition: transform 0.3s ease, border-color 0.3s ease;
@@ -683,7 +683,7 @@ p {
     margin: 0 auto;
     display: grid;
     grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.9fr);
-    gap: 64px;
+    gap: 40px;
     align-items: center;
 }
 
@@ -692,7 +692,7 @@ p {
     margin: 0;
     padding: 0;
     display: grid;
-    gap: 24px;
+    gap: 18px;
 }
 
 .highlight__list span {
@@ -715,7 +715,7 @@ p {
     background: rgba(248, 180, 0, 0.16);
     border: 1px solid rgba(248, 180, 0, 0.6);
     border-radius: var(--radius-md);
-    padding: 18px 24px;
+    padding: 14px 20px;
     text-align: center;
     font-weight: 600;
     color: var(--accent);
@@ -730,7 +730,7 @@ p {
 
 .highlight__image {
     width: 100%;
-    min-height: 340px;
+    min-height: 300px;
     border-radius: var(--radius-lg);
     background: linear-gradient(135deg, rgba(31, 111, 235, 0.4), rgba(11, 13, 23, 0.9)),
         url('https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=1200&q=80') center/cover;
@@ -747,16 +747,16 @@ p {
     margin: 0 auto;
     display: grid;
     grid-template-columns: repeat(3, minmax(0, 1fr));
-    gap: 32px;
+    gap: 24px;
 }
 
 .case-card {
     background: var(--bg-alt);
     border-radius: var(--radius-md);
-    padding: 32px;
+    padding: 26px;
     border: 1px solid rgba(255, 255, 255, 0.06);
     display: grid;
-    gap: 14px;
+    gap: 12px;
     position: relative;
     overflow: hidden;
 }
@@ -797,13 +797,13 @@ p {
     margin: 0 auto;
     display: grid;
     grid-template-columns: repeat(3, minmax(0, 1fr));
-    gap: 28px;
+    gap: 22px;
 }
 
 .testimonial {
     background: rgba(255, 255, 255, 0.03);
     border-radius: var(--radius-md);
-    padding: 28px;
+    padding: 24px;
     border: 1px solid rgba(255, 255, 255, 0.08);
     position: relative;
 }
@@ -811,8 +811,8 @@ p {
 .testimonial::before {
     content: '“';
     position: absolute;
-    top: -24px;
-    left: 24px;
+    top: -18px;
+    left: 20px;
     font-size: 5rem;
     color: rgba(248, 180, 0, 0.2);
 }
@@ -830,7 +830,7 @@ p {
 }
 
 .section--cta {
-    padding: 110px 24px;
+    padding: 84px 24px;
     background: linear-gradient(135deg, rgba(31, 111, 235, 0.7), rgba(11, 13, 23, 0.95));
 }
 
@@ -841,7 +841,7 @@ p {
 }
 
 .cta h2 {
-    font-size: clamp(2rem, 3vw + 1rem, 3rem);
+    font-size: clamp(1.9rem, 2.6vw + 1rem, 2.6rem);
 }
 
 .cta p {
@@ -857,16 +857,16 @@ p {
     margin: 0 auto;
     display: grid;
     grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
-    gap: 48px;
+    gap: 34px;
     align-items: start;
 }
 
 .contact__list {
     list-style: none;
-    margin: 32px 0 0;
+    margin: 24px 0 0;
     padding: 0;
     display: grid;
-    gap: 20px;
+    gap: 16px;
 }
 
 .contact__list span {
@@ -885,18 +885,18 @@ p {
 .contact__form {
     background: rgba(255, 255, 255, 0.04);
     border-radius: var(--radius-lg);
-    padding: 40px;
+    padding: 32px;
     border: 1px solid rgba(255, 255, 255, 0.08);
     box-shadow: var(--shadow);
 }
 
 .contact__form h3 {
-    margin-bottom: 24px;
+    margin-bottom: 20px;
 }
 
 .footer {
     background: #06070e;
-    padding: 48px 24px;
+    padding: 36px 24px;
     color: rgba(255, 255, 255, 0.7);
 }
 
@@ -907,7 +907,7 @@ p {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    gap: 32px;
+    gap: 24px;
 }
 
 .footer__meta p {
@@ -917,7 +917,7 @@ p {
 .footer__links {
     list-style: none;
     display: flex;
-    gap: 22px;
+    gap: 18px;
     margin: 0;
     padding: 0;
 }
@@ -929,12 +929,12 @@ p {
 
 .footer__socials {
     display: flex;
-    gap: 16px;
+    gap: 12px;
 }
 
 .social-icon {
-    width: 42px;
-    height: 42px;
+    width: 36px;
+    height: 36px;
     border-radius: 50%;
     border: 1px solid rgba(255, 255, 255, 0.2);
     display: grid;
@@ -944,11 +944,11 @@ p {
 
 .back-to-top {
     position: fixed;
-    bottom: 32px;
-    right: 32px;
+    bottom: 24px;
+    right: 24px;
     background: rgba(31, 111, 235, 0.92);
     color: #fff;
-    padding: 12px 18px;
+    padding: 10px 16px;
     border-radius: 999px;
     font-weight: 600;
     letter-spacing: 0.08em;
@@ -1063,11 +1063,11 @@ p {
     }
 
     .section {
-        padding: 90px 18px;
+        padding: 60px 18px;
     }
 
     .section__header {
-        margin-bottom: 40px;
+        margin-bottom: 30px;
     }
 
     .cases,
@@ -1088,35 +1088,35 @@ p {
     }
 
     .hero__list li {
-        padding: 14px 16px 14px 40px;
+        padding: 12px 14px 12px 36px;
     }
 
     .hero__list li::before {
-        left: 16px;
+        left: 14px;
     }
 
     .about {
-        gap: 36px;
-    }
-
-    .about__profile {
         gap: 28px;
     }
 
+    .about__profile {
+        gap: 22px;
+    }
+
     .about__portrait {
-        max-width: 360px;
+        max-width: 320px;
     }
 
     .about__details {
-        gap: 20px;
+        gap: 16px;
     }
 
     .about-card {
-        padding: 24px;
+        padding: 22px;
     }
 
     .about-card__list--inline {
-        gap: 10px 16px;
+        gap: 8px 14px;
     }
 
     .footer__top,
@@ -1151,7 +1151,7 @@ p {
     }
 
     .hero__signature {
-        margin-top: 28px;
+        margin-top: 24px;
     }
 
     .services {
@@ -1159,15 +1159,15 @@ p {
     }
 
     .about__highlights li {
-        padding: 16px 18px;
+        padding: 14px 16px;
     }
 
     .about-card {
-        padding: 22px;
+        padding: 20px;
     }
 
     .about__details {
-        gap: 18px;
+        gap: 14px;
     }
 
     .about__portrait {
@@ -1193,7 +1193,7 @@ p {
     }
 
     .back-to-top {
-        bottom: 20px;
-        right: 20px;
+        bottom: 16px;
+        right: 16px;
     }
 }


### PR DESCRIPTION
## Summary
- tighten heading, paragraph, button, and navigation spacing to reduce overall page padding
- compact hero copy, stats, and sidebar card styling along with section spacing for about and services blocks
- shrink gaps, card paddings, and footer/contact spacing to keep the layout consistently condensed on all breakpoints

## Testing
- Not run (static CSS changes)


------
https://chatgpt.com/codex/tasks/task_e_68c9576ded848331a39264e21e177c6b