### PR TITLE
Add accordion layout for compact sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,18 +101,23 @@
 
     <main>
         <section class="section section--about" id="about">
-            <div class="about">
-                <div class="about__intro">
-                    <div class="about__profile">
-                        <div class="about__content">
-                            <p class="section__eyebrow">Лично обо мне</p>
-                            <h2>Я — Алексей Серов, независимый юрист по гражданским делам</h2>
-                            <p>
-                                С 2012 года представляю интересы граждан в судах Москвы и Московской области. Беру на себя
-                                семейные, жилищные, наследственные и другие гражданские споры, продумываю стратегию защиты
-                                и сопровождаю клиента на каждом этапе.
-                            </p>
-                            <ul class="about__highlights">
+            <details class="accordion accordion--wide" open>
+                <summary>
+                    <span class="accordion__eyebrow">Лично обо мне</span>
+                    <h2>Я — Алексей Серов, независимый юрист по гражданским делам</h2>
+                    <p class="accordion__hint">12 лет представляю интересы граждан в Москве и Московской области.</p>
+                </summary>
+                <div class="accordion__content">
+                    <div class="about">
+                        <div class="about__intro">
+                            <div class="about__profile">
+                                <div class="about__content">
+                                    <p class="about__description">
+                                        С 2012 года представляю интересы граждан в судах Москвы и Московской области. Беру на
+                                        себя семейные, жилищные, наследственные и другие гражданские споры, продумываю стратегию
+                                        защиты и сопровождаю клиента на каждом этапе.
+                                    </p>
+                                    <ul class="about__highlights">
                                 <li>
                                     <span>12 лет практики</span>
                                     Представляю клиентов в судах общей юрисдикции Москвы и Подмосковья, готовлю документы и выступаю в заседаниях лично.
@@ -174,14 +179,18 @@
                     </article>
                 </div>
             </div>
+                </div>
+            </details>
         </section>
         <section class="section section--services" id="services">
-            <div class="section__header">
-                <p class="section__eyebrow">Гражданская практика</p>
-                <h2>Ключевые направления работы</h2>
-                <p>Помогаю гражданам пройти весь путь: от первичной консультации и подготовки документов до представительства в суде и исполнении решения.</p>
-            </div>
-            <div class="services">
+            <details class="accordion">
+                <summary>
+                    <span class="accordion__eyebrow">Гражданская практика</span>
+                    <h2>Ключевые направления работы</h2>
+                    <p class="accordion__hint">Полный цикл сопровождения — от консультации до исполнения судебного решения.</p>
+                </summary>
+                <div class="accordion__content">
+                    <div class="services">
                 <article class="service-card">
                     <h3>Семейные дела</h3>
                     <p>Развод, раздел имущества, вопросы алиментов и порядка общения с детьми. Поддержка на каждом этапе.</p>
@@ -209,15 +218,22 @@
                         <li>Защита прав потребителей</li>
                     </ul>
                 </article>
-            </div>
+                    </div>
+                </div>
+            </details>
         </section>
 
         <section class="section section--highlight" id="advantages">
-            <div class="highlight">
-                <div class="highlight__content">
-                    <p class="section__eyebrow">Почему выбирают нас</p>
+            <details class="accordion">
+                <summary>
+                    <span class="accordion__eyebrow">Почему выбирают нас</span>
                     <h2>Партнёр, которому можно доверять</h2>
-                    <ul class="highlight__list">
+                    <p class="accordion__hint">Команда экспертов, прозрачные условия и цифровой кабинет клиента.</p>
+                </summary>
+                <div class="accordion__content">
+                    <div class="highlight">
+                        <div class="highlight__content">
+                            <ul class="highlight__list">
                         <li>
                             <span>Персональная команда экспертов</span>
                             Подбираем профильных специалистов под каждое дело и формируем команду для быстрого результата.
@@ -230,25 +246,30 @@
                             <span>Цифровой кабинет клиента</span>
                             Следите за статусом дела, загружайте документы и общайтесь с юристом в защищённом канале 24/7.
                         </li>
-                    </ul>
-                </div>
-                <div class="highlight__media">
-                    <div class="highlight__badge">
-                        <span>Рейтинг</span>
-                        <strong>Pravo-300</strong>
-                        <span>2023</span>
+                            </ul>
+                        </div>
+                        <div class="highlight__media">
+                            <div class="highlight__badge">
+                                <span>Рейтинг</span>
+                                <strong>Pravo-300</strong>
+                                <span>2023</span>
+                            </div>
+                            <div class="highlight__image" role="img" aria-label="Современный офис юридической команды"></div>
+                        </div>
                     </div>
-                    <div class="highlight__image" role="img" aria-label="Современный офис юридической команды"></div>
                 </div>
-            </div>
+            </details>
         </section>
 
         <section class="section section--cases" id="cases">
-            <div class="section__header">
-                <p class="section__eyebrow">Избранные кейсы</p>
-                <h2>Дела, которые определили практику</h2>
-            </div>
-            <div class="cases">
+            <details class="accordion">
+                <summary>
+                    <span class="accordion__eyebrow">Избранные кейсы</span>
+                    <h2>Дела, которые определили практику</h2>
+                    <p class="accordion__hint">Короткие истории с ключевыми результатами и сроками.</p>
+                </summary>
+                <div class="accordion__content">
+                    <div class="cases">
                 <article class="case-card">
                     <p class="case-card__label">Жилищный спор</p>
                     <h3>Отстояли право собственности на квартиру</h3>
@@ -279,15 +300,20 @@
                         <li>Доли наследников восстановлены</li>
                     </ul>
                 </article>
-            </div>
+                    </div>
+                </div>
+            </details>
         </section>
 
         <section class="section section--testimonials" id="testimonials">
-            <div class="section__header">
-                <p class="section__eyebrow">Отзывы клиентов</p>
-                <h2>Результаты, которые говорят сами за себя</h2>
-            </div>
-            <div class="testimonials">
+            <details class="accordion">
+                <summary>
+                    <span class="accordion__eyebrow">Отзывы клиентов</span>
+                    <h2>Результаты, которые говорят сами за себя</h2>
+                    <p class="accordion__hint">Три коротких истории клиентов о совместной работе.</p>
+                </summary>
+                <div class="accordion__content">
+                    <div class="testimonials">
                 <article class="testimonial">
                     <blockquote>
                         «Алексей помог пройти сложный развод: объяснил каждый шаг, подготовил документы и добился справедливого решения для детей.»
@@ -306,7 +332,9 @@
                     </blockquote>
                     <p class="testimonial__author">Марина Кузнецова, клиентка по защите прав потребителей</p>
                 </article>
-            </div>
+                    </div>
+                </div>
+            </details>
         </section>
 
         <section class="section section--cta">
@@ -318,11 +346,16 @@
         </section>
 
         <section class="section section--contact" id="contact">
-            <div class="contact">
-                <div class="contact__info">
-                    <p class="section__eyebrow">Контакты</p>
+            <details class="accordion accordion--wide">
+                <summary>
+                    <span class="accordion__eyebrow">Контакты</span>
                     <h2>Офис в Одинцово, работаю в Москве и Московской области</h2>
-                    <p>Назначьте встречу в офисе юридической фирмы в центре Одинцово или обсудим дело дистанционно, если вы находитесь в другом городе.</p>
+                    <p class="accordion__hint">Очные встречи и дистанционное сопровождение клиентов.</p>
+                </summary>
+                <div class="accordion__content">
+                    <div class="contact">
+                        <div class="contact__info">
+                            <p class="contact__lead">Назначьте встречу в офисе юридической фирмы в центре Одинцово или обсудим дело дистанционно, если вы находитесь в другом городе.</p>
                     <ul class="contact__list">
                         <li>
                             <span>Телефон</span>
@@ -364,8 +397,10 @@
                         <button type="submit" class="btn btn--primary">Отправить заявку</button>
                         <p class="form__policy">Нажимая кнопку, вы даёте согласие на обработку персональных данных.</p>
                     </form>
+                        </div>
+                    </div>
                 </div>
-            </div>
+            </details>
         </section>
     </main>
 

--- a/script.js
+++ b/script.js
@@ -1,6 +1,7 @@
 const navToggle = document.querySelector('.nav__toggle');
 const navLinks = document.querySelector('.nav__links');
 const backToTop = document.getElementById('backToTop');
+const accordions = Array.from(document.querySelectorAll('.accordion'));
 
 if (navToggle) {
     navToggle.addEventListener('click', () => {
@@ -19,6 +20,71 @@ navLinks?.querySelectorAll('a').forEach((link) => {
         }
     });
 });
+
+if (accordions.length) {
+    const closeOtherAccordions = (current) => {
+        accordions.forEach((accordion) => {
+            if (accordion !== current) {
+                accordion.removeAttribute('open');
+            }
+        });
+    };
+
+    const openAccordionFromHash = (hash) => {
+        if (!hash || hash === '#') {
+            return;
+        }
+
+        try {
+            const target = document.querySelector(hash);
+            if (!target) {
+                return;
+            }
+
+            const accordion = target.classList.contains('accordion')
+                ? target
+                : target.querySelector('.accordion');
+
+            if (!accordion) {
+                return;
+            }
+
+            accordion.setAttribute('open', '');
+            closeOtherAccordions(accordion);
+        } catch (error) {
+            // ignore invalid selectors
+        }
+    };
+
+    accordions.forEach((accordion) => {
+        accordion.addEventListener('toggle', () => {
+            if (accordion.open) {
+                closeOtherAccordions(accordion);
+            }
+        });
+    });
+
+    document.querySelectorAll('a[href^="#"]').forEach((link) => {
+        link.addEventListener('click', () => {
+            const hash = link.getAttribute('href');
+            if (!hash || hash === '#') {
+                return;
+            }
+
+            requestAnimationFrame(() => {
+                openAccordionFromHash(hash);
+            });
+        });
+    });
+
+    window.addEventListener('hashchange', () => {
+        openAccordionFromHash(window.location.hash);
+    });
+
+    if (window.location.hash) {
+        openAccordionFromHash(window.location.hash);
+    }
+}
 
 function handleFormSubmit(form) {
     form.addEventListener('submit', (event) => {

--- a/styles.css
+++ b/styles.css
@@ -407,7 +407,112 @@ p {
 }
 
 .section {
-    padding: 56px 24px;
+    padding: 36px 20px;
+}
+
+main {
+    display: grid;
+    gap: 20px;
+}
+
+.accordion {
+    display: block;
+    margin: 0 auto;
+    max-width: var(--max-width);
+    border-radius: var(--radius-lg);
+    background: rgba(16, 20, 37, 0.72);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    backdrop-filter: blur(14px);
+    overflow: hidden;
+    transition: box-shadow 0.3s ease, border-color 0.3s ease, transform 0.3s ease;
+}
+
+.accordion--wide {
+    max-width: calc(var(--max-width) + 140px);
+}
+
+.section--highlight .accordion,
+.section--cases .accordion,
+.section--testimonials .accordion {
+    background: rgba(15, 19, 36, 0.82);
+}
+
+.accordion summary {
+    list-style: none;
+    display: grid;
+    gap: 6px;
+    padding: 20px 64px 20px 24px;
+    cursor: pointer;
+    position: relative;
+}
+
+.accordion summary::-webkit-details-marker {
+    display: none;
+}
+
+.accordion summary::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    right: 24px;
+    width: 12px;
+    height: 12px;
+    border-right: 2px solid rgba(255, 255, 255, 0.6);
+    border-bottom: 2px solid rgba(255, 255, 255, 0.6);
+    transform: translateY(-50%) rotate(45deg);
+    transition: transform 0.3s ease, border-color 0.3s ease;
+}
+
+.accordion[open] summary::after {
+    transform: translateY(-50%) rotate(-135deg);
+    border-color: var(--accent);
+}
+
+.accordion summary:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 6px;
+}
+
+.accordion:hover,
+.accordion:focus-within {
+    border-color: rgba(248, 180, 0, 0.35);
+    box-shadow: 0 18px 40px rgba(15, 23, 42, 0.45);
+    transform: translateY(-1px);
+}
+
+.accordion summary h2 {
+    margin: 0;
+}
+
+.accordion__eyebrow {
+    font-size: 0.8rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--accent);
+}
+
+.accordion__hint {
+    margin: 0;
+    color: rgba(247, 247, 251, 0.75);
+    font-size: 0.95rem;
+    max-width: 680px;
+}
+
+.accordion__content {
+    padding: 0 24px 24px;
+}
+
+.accordion__content > * + * {
+    margin-top: 24px;
+}
+
+.accordion[open] summary {
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+    margin-bottom: 8px;
+}
+
+.accordion:not([open]) .accordion__content {
+    display: none;
 }
 
 .section__header {
@@ -514,6 +619,12 @@ p {
 
 .about__intro p {
     color: rgba(255, 255, 255, 0.78);
+}
+
+.about__description {
+    margin: 0 0 18px;
+    color: rgba(255, 255, 255, 0.78);
+    font-size: 0.98rem;
 }
 
 .about__highlights {
@@ -645,16 +756,16 @@ p {
     max-width: var(--max-width);
     margin: 0 auto;
     display: grid;
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-    gap: 20px;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 18px;
 }
 
 .service-card {
     background: var(--bg-alt);
     border-radius: var(--radius-md);
-    padding: 24px;
+    padding: 20px;
     border: 1px solid var(--border);
-    box-shadow: 0 16px 30px rgba(10, 12, 20, 0.45);
+    box-shadow: 0 14px 26px rgba(10, 12, 20, 0.45);
     transition: transform 0.3s ease, border-color 0.3s ease;
 }
 
@@ -683,7 +794,7 @@ p {
     margin: 0 auto;
     display: grid;
     grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.9fr);
-    gap: 40px;
+    gap: 28px;
     align-items: center;
 }
 
@@ -746,14 +857,14 @@ p {
     max-width: var(--max-width);
     margin: 0 auto;
     display: grid;
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-    gap: 24px;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 18px;
 }
 
 .case-card {
     background: var(--bg-alt);
     border-radius: var(--radius-md);
-    padding: 26px;
+    padding: 22px;
     border: 1px solid rgba(255, 255, 255, 0.06);
     display: grid;
     gap: 12px;
@@ -796,14 +907,14 @@ p {
     max-width: var(--max-width);
     margin: 0 auto;
     display: grid;
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-    gap: 22px;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 18px;
 }
 
 .testimonial {
     background: rgba(255, 255, 255, 0.03);
     border-radius: var(--radius-md);
-    padding: 24px;
+    padding: 20px;
     border: 1px solid rgba(255, 255, 255, 0.08);
     position: relative;
 }
@@ -811,7 +922,7 @@ p {
 .testimonial::before {
     content: '“';
     position: absolute;
-    top: -18px;
+    top: -14px;
     left: 20px;
     font-size: 5rem;
     color: rgba(248, 180, 0, 0.2);
@@ -830,7 +941,7 @@ p {
 }
 
 .section--cta {
-    padding: 84px 24px;
+    padding: 60px 24px;
     background: linear-gradient(135deg, rgba(31, 111, 235, 0.7), rgba(11, 13, 23, 0.95));
 }
 
@@ -859,6 +970,13 @@ p {
     grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
     gap: 34px;
     align-items: start;
+}
+
+.contact__lead {
+    margin: 0 0 20px;
+    color: rgba(255, 255, 255, 0.78);
+    font-size: 0.98rem;
+    max-width: 560px;
 }
 
 .contact__list {
@@ -1055,16 +1173,12 @@ body.modal-open {
 }
 
 @media (max-width: 1080px) {
-    .services {
-        grid-template-columns: repeat(2, minmax(0, 1fr));
+    .accordion--wide {
+        max-width: var(--max-width);
     }
 
-    .cases {
-        grid-template-columns: repeat(2, minmax(0, 1fr));
-    }
-
-    .testimonials {
-        grid-template-columns: repeat(2, minmax(0, 1fr));
+    main {
+        gap: 14px;
     }
 
     .highlight {
@@ -1150,7 +1264,27 @@ body.modal-open {
     }
 
     .section {
-        padding: 60px 18px;
+        padding: 44px 16px;
+    }
+
+    main {
+        gap: 12px;
+    }
+
+    .accordion {
+        border-radius: var(--radius-md);
+    }
+
+    .accordion summary {
+        padding: 18px 52px 18px 20px;
+    }
+
+    .accordion summary::after {
+        right: 20px;
+    }
+
+    .accordion__content {
+        padding: 0 20px 20px;
     }
 
     .section__header {


### PR DESCRIPTION
## Summary
- wrap long informational sections in accordions to collapse content by default and shorten the page
- refresh spacing, grids, and typography so opened sections look balanced in the compact layout
- add JavaScript helpers that keep only one accordion open and expand sections when navigation anchors are used

## Testing
- No automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cb102e6590833199ee6f08d03248df