### PR TITLE
Improve section alignment when navigating via anchors

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -13,6 +13,7 @@
     --radius-md: 20px;
     --radius-sm: 12px;
     --max-width: 1180px;
+    --scroll-offset: clamp(72px, 12vh, 160px);
     --font-family: 'Manrope', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 }
 
@@ -408,6 +409,11 @@ p {
 
 .section {
     padding: 36px 20px;
+}
+
+.hero,
+.section {
+    scroll-margin-top: var(--scroll-offset);
 }
 
 main {


### PR DESCRIPTION
## Summary
- add a shared scroll offset custom property
- apply scroll-margin to hero and section blocks so anchors are fully visible after navigation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb15e8c448833193337ea5a8e640f2